### PR TITLE
docs: note tested paddlepaddle and paddleocr versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ pip install openvino pyyaml opencv-python numpy
 
 This is only required for paddlepaddle backend.
 
+> Tested with `paddlepaddle==3.0.0` and `paddleocr==3.4.0`.
+
 Install PaddlePaddle following the official installation guide for your OS / Python / CUDA version:
 
 - https://www.paddlepaddle.org.cn/en/install/quick


### PR DESCRIPTION
## Summary
- Add a note under `### For Paddle Backend (Optional)` mentioning the tested versions (`paddlepaddle==3.0.0`, `paddleocr==3.4.0`).

## Test plan
- [ ] Render README on GitHub and confirm the note appears under the Paddle Backend section.